### PR TITLE
Bug/otherSyncedHiRCalendarTIs

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -36,7 +36,7 @@ class App extends Component {
   componentDidMount() {
     gapi.load('client:auth2', async () => {
       const scope = [
-        'https://www.googleapis.com/auth/calendar', 
+        'https://www.googleapis.com/auth/calendar',
         'https://www.googleapis.com/auth/drive',
         'https://www.googleapis.com/auth/spreadsheets.readonly',
         ].join(' ');
@@ -45,7 +45,7 @@ class App extends Component {
       this.GoogleAuth = gapi.auth2.getAuthInstance();
       this.logout = this.GoogleAuth.disconnect.bind(this.GoogleAuth);
       this.GoogleAuth.isSignedIn.listen(this.handleLogin);
-      this.GoogleAuth.isSignedIn.get() ? 
+      this.GoogleAuth.isSignedIn.get() ?
         this.handleLogin() :
         this.setState({ loggedIn: false });
     });
@@ -112,15 +112,13 @@ class App extends Component {
       const { result: { items: calendars } } = await gapi.client.request({
         path: 'https://www.googleapis.com/calendar/v3/users/me/calendarList',
       });
-      const loggedInSplit = this.state.loggedIn.split(' ');
-      const loggedInFirstNameLC = loggedInSplit[0].toLowerCase();
-      const loggedInLastNameLC = loggedInSplit[loggedInSplit.length - 1].toLowerCase();
+      const loggedInLC = this.state.loggedIn.replace(/\s/g, '.').toLowerCase();
       let hirCalendarId;
       try {
         const hirCalendarsSubscribed = calendars.filter(
           ({ summary }) => summary.includes('HiR'));
         const hirCalendarLoggedIn = hirCalendarsSubscribed.filter(
-          ({ summary }) => summary.includes(loggedInFirstNameLC) && summary.includes(loggedInLastNameLC))[0] || hirCalendarsSubscribed[0];
+          ({ summary }) => summary.includes(loggedInLC))[0] || hirCalendarsSubscribed[0];
         hirCalendarId = hirCalendarLoggedIn.id;
       } catch (err) {
         console.error(err);

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -112,16 +112,15 @@ class App extends Component {
       const { result: { items: calendars } } = await gapi.client.request({
         path: 'https://www.googleapis.com/calendar/v3/users/me/calendarList',
       });
-
-      const loggedInLC = this.state.loggedIn.toLowerCase();
-      let hirCalendarsSubscribed;
-      let hirCalendarLoggedIn;
+      const loggedInSplit = this.state.loggedIn.split(' ');
+      const loggedInFirstNameLC = loggedInSplit[0].toLowerCase();
+      const loggedInLastNameLC = loggedInSplit[loggedInSplit.length - 1].toLowerCase();
       let hirCalendarId;
       try {
-        hirCalendarsSubscribed = calendars.filter(
+        const hirCalendarsSubscribed = calendars.filter(
           ({ summary }) => summary.includes('HiR'));
-        hirCalendarLoggedIn = hirCalendarsSubscribed.find(
-          ({ summary }) => summary.includes(loggedInLC)) || hirCalendarsSubscribed[0];
+        const hirCalendarLoggedIn = hirCalendarsSubscribed.filter(
+          ({ summary }) => summary.includes(loggedInFirstNameLC) && summary.includes(loggedInLastNameLC))[0] || hirCalendarsSubscribed[0];
         hirCalendarId = hirCalendarLoggedIn.id;
       } catch (err) {
         console.error(err);
@@ -188,7 +187,7 @@ class App extends Component {
         liveTiRows: null,
       });
     } else {
-      const loggedIn = this.GoogleAuth.currentUser.get().getBasicProfile().getName().split(' ')[0];
+      const loggedIn = this.GoogleAuth.currentUser.get().getBasicProfile().getName();
       this.setState({ loggedIn });
       this.getCalendarData();
     }

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -118,8 +118,6 @@ class App extends Component {
       let hirCalendarLoggedIn;
       let hirCalendarId;
       try {
-        // hirCalendarId = calendars.filter(
-        //   ({ summary }) => summary.includes('HiR'))[0].id;
         hirCalendarsSubscribed = calendars.filter(
           ({ summary }) => summary.includes('HiR'));
         hirCalendarLoggedIn = hirCalendarsSubscribed.find(

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -109,14 +109,22 @@ class App extends Component {
 
   getCalendarData = async () => {
     try {
-      const {result: { items: calendars } } = await gapi.client.request({
+      const { result: { items: calendars } } = await gapi.client.request({
         path: 'https://www.googleapis.com/calendar/v3/users/me/calendarList',
       });
 
+      const loggedInLC = this.state.loggedIn.toLowerCase();
+      let hirCalendarsSubscribed;
+      let hirCalendarLoggedIn;
       let hirCalendarId;
       try {
-        hirCalendarId = calendars.filter(
-          ({ summary }) => summary.includes('HiR'))[0].id;
+        // hirCalendarId = calendars.filter(
+        //   ({ summary }) => summary.includes('HiR'))[0].id;
+        hirCalendarsSubscribed = calendars.filter(
+          ({ summary }) => summary.includes('HiR'));
+        hirCalendarLoggedIn = hirCalendarsSubscribed.find(
+          ({ summary }) => summary.includes(loggedInLC)) || hirCalendarsSubscribed[0];
+        hirCalendarId = hirCalendarLoggedIn.id;
       } catch (err) {
         console.error(err);
         alert(`You don't seem to be using your Hack Reactor account! Just log in again with the right account.`);
@@ -124,7 +132,7 @@ class App extends Component {
         return;
       }
 
-      const {result: {items: [interview] } } = await gapi.client.request({
+      const { result: {items: [interview] } } = await gapi.client.request({
         path: `https://www.googleapis.com/calendar/v3/calendars/${hirCalendarId}/events`,
         params: {
           singleEvents: true,

--- a/client/components/Setup.jsx
+++ b/client/components/Setup.jsx
@@ -50,6 +50,7 @@ class Setup extends Component {
         startTime.format('LT dddd [the] Do'))
       : null;
     const interviewDate = (startTime || moment()).format('YYYY-MM-DD');
+    const loggedInFirstName = loggedIn.split(' ')[0];
 
     return (
       <div className="setup">
@@ -57,7 +58,7 @@ class Setup extends Component {
         {this.state.show ? 
           <div>
             {startTime ? 
-              <div> Hi {loggedIn}! Your interview with {candidateName} starts at {interviewTime}.
+              <div> Hi {loggedInFirstName}! Your interview with {candidateName} starts at {interviewTime}.
                 <br />(Not {loggedIn}? <a href='#' onClick={logout}>Click here.</a>)
               </div> :
               <div> {loggedIn ? 

--- a/client/components/Setup.jsx
+++ b/client/components/Setup.jsx
@@ -50,15 +50,14 @@ class Setup extends Component {
         startTime.format('LT dddd [the] Do'))
       : null;
     const interviewDate = (startTime || moment()).format('YYYY-MM-DD');
-    const loggedInFirstName = loggedIn.split(' ')[0];
 
     return (
       <div className="setup">
         <h4 onClick={this.toggleShow}> Setup </h4>
         {this.state.show ? 
           <div>
-            {startTime ? 
-              <div> Hi {loggedInFirstName}! Your interview with {candidateName} starts at {interviewTime}.
+            {startTime ?
+              <div> Hi {loggedIn.split(' ')[0]}! Your interview with {candidateName} starts at {interviewTime}.
                 <br />(Not {loggedIn}? <a href='#' onClick={logout}>Click here.</a>)
               </div> :
               <div> {loggedIn ? 

--- a/client/components/searchLiveTiHistory.js
+++ b/client/components/searchLiveTiHistory.js
@@ -12,7 +12,7 @@ const formatLiveTiRow = row => {
 
 const processLiveTiData = (data, email) => {
   const { result: { sheets: [sheet] } } = data;
-  const { data: [{ rowData : rows }]} = sheet;
+  const { data: [{ rowData : rows }] } = sheet;
   const unformattedLiveTiRows = rows.map(({ values }) => values).filter(values => {
     const { formattedValue: rowEmail } = values[4];
     // rowEmail && avoids problems with the many empty rows at the bottom of the sheet.


### PR DESCRIPTION
Hi Sam!

Here's the Trello ticket for the bug description: https://trello.com/c/XFXRdN2c/1-viewfinder-may-pull-tis-from-other-hirs-calendars-if-the-logged-in-hir-has-synced-other-calendars

Please let me know what you think, especially about the time/space complexity.  

Note that this solution filters based on an HiR's first name, so if there are two HiR calendars with the first name Sam, it will pull the first one, regardless of who the actual logged-in user is.  Using the loggedIn property (i.e., the first name) is easily accessible, but perhaps storing (and filtering by) the loggedIn user's full name may be best.

Thanks,
Aaron
