### PR TITLE
Allow webpack to ignore moment.js locales when bundling

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   entry: ['babel-polyfill', __dirname + '/client/components/App.jsx'],
   module: {
@@ -21,5 +23,8 @@ module.exports = {
     filename: 'bundle.js',
     library: 'App',
     libraryTarget: 'var'
-  }
+  },
+  plugins: [
+    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+  ]
 };


### PR DESCRIPTION
This PR fixes #11 to make webpack bundling smaller and faster!